### PR TITLE
Correct misspelling of architectures field name

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=RobotDyn Keypad 3x4 Analog library for Arduino
 paragraph=This is a RobotDyn Keypad 3x4 with analog output library for Arduino.
 category=Device Control
 url=https://github.com/Erriez/ErriezRobotDynKeypad3x4Analog
-architecture=*
+architectures=*


### PR DESCRIPTION
The correct spelling of the field name is architectures, not architecture.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format